### PR TITLE
Add unsafe slice conversions

### DIFF
--- a/gopy/byteu.go
+++ b/gopy/byteu.go
@@ -6,6 +6,15 @@ import (
 	"unsafe"
 )
 
+// verify little-endian at startup
+var _ = func() any {
+	var i uint16 = 1
+	if *(*byte)(unsafe.Pointer(&i)) != 1 {
+		panic("gopy only supports little-endian architectures")
+	}
+	return nil
+}()
+
 func int32ToBytes1D(src []int32, dest []byte) {
 	i := 0
 	for _, val := range src {
@@ -199,12 +208,84 @@ func bytesToFloat641D(src []byte, result []float64) {
 	}
 }
 
-// ----  UNSAFE VERSIONS WIP ----
+// ----  UNSAFE VERSIONS ----
 
-func int32ToBytes1DUnsafe(s []int32) []byte {
-	if len(s) == 0 {
-		return []byte{}
+func int16ToBytes1DUnsafe(src []int16, dest []byte) {
+	if len(src) == 0 {
+		return
 	}
-	sliceHeader := unsafe.SliceData(s)
-	return *(*[]byte)(unsafe.Pointer(sliceHeader))
+	bs := unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*2)
+	copy(dest, bs)
+}
+
+func int32ToBytes1DUnsafe(src []int32, dest []byte) {
+	if len(src) == 0 {
+		return
+	}
+	bs := unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*4)
+	copy(dest, bs)
+}
+
+func int64ToBytes1DUnsafe(src []int64, dest []byte) {
+	if len(src) == 0 {
+		return
+	}
+	bs := unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*8)
+	copy(dest, bs)
+}
+
+func float32ToBytes1DUnsafe(src []float32, dest []byte) {
+	if len(src) == 0 {
+		return
+	}
+	bs := unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*4)
+	copy(dest, bs)
+}
+
+func float64ToBytes1DUnsafe(src []float64, dest []byte) {
+	if len(src) == 0 {
+		return
+	}
+	bs := unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*8)
+	copy(dest, bs)
+}
+
+func bytesToInt161DUnsafe(src []byte, result []int16) {
+	if len(result) == 0 {
+		return
+	}
+	ints := unsafe.Slice((*int16)(unsafe.Pointer(&src[0])), len(result))
+	copy(result, ints)
+}
+
+func bytesToInt321DUnsafe(src []byte, result []int32) {
+	if len(result) == 0 {
+		return
+	}
+	ints := unsafe.Slice((*int32)(unsafe.Pointer(&src[0])), len(result))
+	copy(result, ints)
+}
+
+func bytesToInt641DUnsafe(src []byte, result []int64) {
+	if len(result) == 0 {
+		return
+	}
+	ints := unsafe.Slice((*int64)(unsafe.Pointer(&src[0])), len(result))
+	copy(result, ints)
+}
+
+func bytesToFloat321DUnsafe(src []byte, result []float32) {
+	if len(result) == 0 {
+		return
+	}
+	floats := unsafe.Slice((*float32)(unsafe.Pointer(&src[0])), len(result))
+	copy(result, floats)
+}
+
+func bytesToFloat641DUnsafe(src []byte, result []float64) {
+	if len(result) == 0 {
+		return
+	}
+	floats := unsafe.Slice((*float64)(unsafe.Pointer(&src[0])), len(result))
+	copy(result, floats)
 }

--- a/gopy/types.go
+++ b/gopy/types.go
@@ -86,7 +86,7 @@ func (arr Float32_Array) MarshalMsgpack() ([]byte, error) {
 	b[0] = 0xC9
 	binary.BigEndian.PutUint32(b[1:5], l)
 	b[5] = byte(ExtFloat32)
-	float32ToBytes1D(arr, b[6:])
+	float32ToBytes1DUnsafe(arr, b[6:])
 	return b, nil
 }
 
@@ -96,7 +96,7 @@ func (arr *Float32_Array) UnmarshalMsgpack(data []byte) error {
 		return err
 	}
 	*arr = make(Float32_Array, len(data)/4)
-	bytesToFloat321D(data, *arr)
+	bytesToFloat321DUnsafe(data, *arr)
 	return nil
 }
 
@@ -183,7 +183,7 @@ func (arr Float64_Array) MarshalMsgpack() ([]byte, error) {
 	b[0] = 0xC9
 	binary.BigEndian.PutUint32(b[1:5], uint32(l))
 	b[5] = byte(ExtFloat64)
-	float64ToBytes1D(arr, b[6:])
+	float64ToBytes1DUnsafe(arr, b[6:])
 	return b, nil
 }
 
@@ -193,7 +193,7 @@ func (arr *Float64_Array) UnmarshalMsgpack(data []byte) error {
 		return err
 	}
 	*arr = make(Float64_Array, len(data)/8)
-	bytesToFloat641D(data, *arr)
+	bytesToFloat641DUnsafe(data, *arr)
 	return nil
 }
 
@@ -280,7 +280,7 @@ func (arr Int16_Array) MarshalMsgpack() ([]byte, error) {
 	b[0] = 0xC9
 	binary.BigEndian.PutUint32(b[1:5], l)
 	b[5] = byte(ExtInt16)
-	int16ToBytes1D(arr, b[6:])
+	int16ToBytes1DUnsafe(arr, b[6:])
 	return b, nil
 }
 
@@ -290,7 +290,7 @@ func (arr *Int16_Array) UnmarshalMsgpack(data []byte) error {
 		return err
 	}
 	*arr = make(Int16_Array, len(data)/2)
-	bytesToInt161D(data, *arr)
+	bytesToInt161DUnsafe(data, *arr)
 	return nil
 }
 
@@ -343,7 +343,7 @@ func (arr Int32_Array) MarshalMsgpack() ([]byte, error) {
 	b[0] = 0xC9
 	binary.BigEndian.PutUint32(b[1:5], l)
 	b[5] = byte(ExtInt32)
-	int32ToBytes1D(arr, b[6:])
+	int32ToBytes1DUnsafe(arr, b[6:])
 	return b, nil
 }
 
@@ -353,7 +353,7 @@ func (arr *Int32_Array) UnmarshalMsgpack(data []byte) error {
 		return err
 	}
 	*arr = make(Int32_Array, len(data)/4)
-	bytesToInt321D(data, *arr)
+	bytesToInt321DUnsafe(data, *arr)
 	return nil
 }
 
@@ -440,7 +440,7 @@ func (arr Int64_Array) MarshalMsgpack() ([]byte, error) {
 	b[0] = 0xC9
 	binary.BigEndian.PutUint32(b[1:5], l)
 	b[5] = byte(ExtInt64)
-	int64ToBytes1D(arr, b[6:])
+	int64ToBytes1DUnsafe(arr, b[6:])
 	return b, nil
 }
 
@@ -450,7 +450,7 @@ func (arr *Int64_Array) UnmarshalMsgpack(data []byte) error {
 		return err
 	}
 	*arr = make(Int64_Array, len(data)/8)
-	bytesToInt641D(data, *arr)
+	bytesToInt641DUnsafe(data, *arr)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- provide unsafe endian check
- add optimized unsafe slice conversion helpers
- use unsafe conversions in type marshalling

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887b41ec7e88331a8b7d1a8967ad21b