### PR TITLE
Optimize serialization using unsafe copy

### DIFF
--- a/gopy/byteu.go
+++ b/gopy/byteu.go
@@ -6,11 +6,25 @@ import (
 	"unsafe"
 )
 
+var isLittleEndian bool
+
+func init() {
+	var i uint16 = 1
+	isLittleEndian = *(*byte)(unsafe.Pointer(&i)) == 1
+}
+
 func int32ToBytes1D(src []int32, dest []byte) {
-	i := 0
-	for _, val := range src {
-		binary.LittleEndian.PutUint32(dest[i:i+4], uint32(val))
-		i += 4
+	if len(src) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(dest, unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*4))
+	} else {
+		i := 0
+		for _, val := range src {
+			binary.LittleEndian.PutUint32(dest[i:i+4], uint32(val))
+			i += 4
+		}
 	}
 }
 
@@ -39,10 +53,17 @@ func int32ToBytes3D(s [][][]int32, dest []byte) {
 }
 
 func int16ToBytes1D(src []int16, dest []byte) {
-	i := 0
-	for _, val := range src {
-		binary.LittleEndian.PutUint16(dest[i:i+2], uint16(val))
-		i += 2
+	if len(src) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(dest, unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*2))
+	} else {
+		i := 0
+		for _, val := range src {
+			binary.LittleEndian.PutUint16(dest[i:i+2], uint16(val))
+			i += 2
+		}
 	}
 }
 
@@ -72,10 +93,17 @@ func int16ToBytes3D(s [][][]int16, dest []byte) {
 
 // Int64 versions
 func int64ToBytes1D(src []int64, dest []byte) {
-	i := 0
-	for _, val := range src {
-		binary.LittleEndian.PutUint64(dest[i:i+8], uint64(val))
-		i += 8
+	if len(src) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(dest, unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*8))
+	} else {
+		i := 0
+		for _, val := range src {
+			binary.LittleEndian.PutUint64(dest[i:i+8], uint64(val))
+			i += 8
+		}
 	}
 }
 
@@ -105,10 +133,17 @@ func int64ToBytes3D(s [][][]int64, dest []byte) {
 
 // Float32 versions
 func float32ToBytes1D(src []float32, dest []byte) {
-	i := 0
-	for _, val := range src {
-		binary.LittleEndian.PutUint32(dest[i:i+4], math.Float32bits(val))
-		i += 4
+	if len(src) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(dest, unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*4))
+	} else {
+		i := 0
+		for _, val := range src {
+			binary.LittleEndian.PutUint32(dest[i:i+4], math.Float32bits(val))
+			i += 4
+		}
 	}
 }
 
@@ -138,10 +173,17 @@ func float32ToBytes3D(s [][][]float32, dest []byte) {
 
 // Float64 versions
 func float64ToBytes1D(src []float64, dest []byte) {
-	i := 0
-	for _, val := range src {
-		binary.LittleEndian.PutUint64(dest[i:i+8], math.Float64bits(val))
-		i += 8
+	if len(src) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(dest, unsafe.Slice((*byte)(unsafe.Pointer(&src[0])), len(src)*8))
+	} else {
+		i := 0
+		for _, val := range src {
+			binary.LittleEndian.PutUint64(dest[i:i+8], math.Float64bits(val))
+			i += 8
+		}
 	}
 }
 
@@ -170,32 +212,67 @@ func float64ToBytes3D(s [][][]float64, dest []byte) {
 }
 
 func bytesToInt161D(src []byte, result []int16) {
-	for i := 0; i < len(result); i++ {
-		result[i] = int16(binary.LittleEndian.Uint16(src[i*2 : i*2+2]))
+	if len(result) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), len(result)*2), src[:len(result)*2])
+	} else {
+		for i := 0; i < len(result); i++ {
+			result[i] = int16(binary.LittleEndian.Uint16(src[i*2 : i*2+2]))
+		}
 	}
 }
 
 func bytesToInt321D(src []byte, result []int32) {
-	for i := 0; i < len(result); i++ {
-		result[i] = int32(binary.LittleEndian.Uint32(src[i*4 : i*4+4]))
+	if len(result) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), len(result)*4), src[:len(result)*4])
+	} else {
+		for i := 0; i < len(result); i++ {
+			result[i] = int32(binary.LittleEndian.Uint32(src[i*4 : i*4+4]))
+		}
 	}
 }
 
 func bytesToInt641D(src []byte, result []int64) {
-	for i := 0; i < len(result); i++ {
-		result[i] = int64(binary.LittleEndian.Uint64(src[i*8 : i*8+8]))
+	if len(result) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), len(result)*8), src[:len(result)*8])
+	} else {
+		for i := 0; i < len(result); i++ {
+			result[i] = int64(binary.LittleEndian.Uint64(src[i*8 : i*8+8]))
+		}
 	}
 }
 
 func bytesToFloat321D(src []byte, result []float32) {
-	for i := 0; i < len(result); i++ {
-		result[i] = math.Float32frombits(binary.LittleEndian.Uint32(src[i*4 : i*4+4]))
+	if len(result) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), len(result)*4), src[:len(result)*4])
+	} else {
+		for i := 0; i < len(result); i++ {
+			result[i] = math.Float32frombits(binary.LittleEndian.Uint32(src[i*4 : i*4+4]))
+		}
 	}
 }
 
 func bytesToFloat641D(src []byte, result []float64) {
-	for i := 0; i < len(result); i++ {
-		result[i] = math.Float64frombits(binary.LittleEndian.Uint64(src[i*8 : i*8+8]))
+	if len(result) == 0 {
+		return
+	}
+	if isLittleEndian {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), len(result)*8), src[:len(result)*8])
+	} else {
+		for i := 0; i < len(result); i++ {
+			result[i] = math.Float64frombits(binary.LittleEndian.Uint64(src[i*8 : i*8+8]))
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- optimize slice to/from byte conversions by avoiding per-element loops
- detect little-endian architectures and use direct memory copy

## Testing
- `go test -run TestCall -v`

------
https://chatgpt.com/codex/tasks/task_e_6887c26f371883319b9d0342cb171757